### PR TITLE
Add new rule `no-mixed-expectation-groups`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -147,7 +147,7 @@
     "no-unreachable": "error",
     "no-console": "error",
     "@typescript-eslint/no-unnecessary-condition": [
-      "warn"
+      "error"
     ],
     "eslint-plugin/require-meta-docs-description": "error",
     "eslint-plugin/require-meta-docs-url": "error",

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ To enable this configuration with `.eslintrc`, use the `extends` property:
 
 | Name                                                                               | Description                                                                               | 💼 |
 | :--------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------- | :- |
+| [no-mixed-expectation-groups](docs/rules/no-mixed-expectation-groups.md)           | Disallow mixing expectations for different variables between each other.                  |    |
 | [no-useless-matcher-to-be-defined](docs/rules/no-useless-matcher-to-be-defined.md) | Disallow using `.toBeDefined()` matcher when it is known that variable is always defined. | ✅  |
 | [no-useless-matcher-to-be-null](docs/rules/no-useless-matcher-to-be-null.md)       | Disallow using `.toBeNull()` when TypeScript types conflict with it.                      | ✅  |
 

--- a/docs/rules/no-mixed-expectation-groups.md
+++ b/docs/rules/no-mixed-expectation-groups.md
@@ -1,0 +1,37 @@
+# Disallow mixing expectations for different variables between each other (`proper-tests/no-mixed-expectation-groups`)
+
+<!-- end auto-generated rule header -->
+
+## Rule details
+
+This rule disallows mixing expectations for different variables between each other.
+
+The following patterns are considered errors:
+
+```ts
+// example 1
+expect(foo).toBeDefined();
+expect(bar).toBeNull();
+expect(foo).toHaveLength(3); // should be placed before "bar"
+
+// example 1
+expect(foo).toBeDefined();
+expect(bar).toBeNull();
+expect(foo.bars).toHaveLength(3); // should be placed before "bar"
+```
+
+The following patterns are considered correct:
+
+```ts
+// example 1
+expect(foo).toBeDefined();
+expect(foo).toHaveLength(3);
+
+expect(bar).toBeNull();
+
+// example 2
+expect(foo).toBeDefined();
+expect(foo.bars).toHaveLength(3);
+
+expect(bar).toBeNull();
+```

--- a/src/custom-rules/no-mixed-expectation-groups.spec.ts
+++ b/src/custom-rules/no-mixed-expectation-groups.spec.ts
@@ -1,0 +1,279 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { noMixedExpectationGroups } from './no-mixed-expectation-groups';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('no-mixed-expectation-groups', noMixedExpectationGroups, {
+  valid: [
+    {
+      name: 'with no expectations using "test"',
+      code: `test('should pass')`,
+    },
+    {
+      name: 'with no expectations and using "it"',
+      code: `it('should pass')`,
+    },
+    {
+      name: 'with no expectations and empty body using "test"',
+      code: `test('should pass', () => {})`,
+    },
+    {
+      name: 'with "test.skip"',
+      code: `test.skip('should pass', () => {})`,
+    },
+    {
+      name: 'with "it.skip"',
+      code: `it.skip('should pass', () => {})`,
+    },
+    {
+      name: 'with method call from variable',
+      code: `expect(someObject)[key[test]]('test');`,
+    },
+    {
+      name: 'when the first expect is variable1 with "test"',
+      code: `
+                test('should pass', function () {
+                  expect(variable1).toBeDefined();
+                });
+                `,
+    },
+    {
+      name: 'when the first expect is variable1 with property property1 with "test"',
+      code: `
+                test('should pass', function () {
+                  expect(variable1.property1).toBeDefined();
+                });
+                `,
+    },
+    {
+      name: 'when variable is used in multiple tests with "test"',
+      code: `
+                test.each('should pass', function () {
+                  expect(variable1).toBeDefined();
+                });
+                test.each('should pass', function () {
+                  expect(variable1).toMatchObject({});
+                });
+                `,
+    },
+    {
+      name: 'when variable is used in multiple tests with "test" and "it", with several expectations',
+      code: `
+                it('should pass1', function () {
+                  expect(someObject).toBeDefined();
+                  expect(someObject).toMatchObject({});
+                });
+                test('should pass2', function () {
+                  expect(someObject).toBeDefined();
+                  expect(someObject).toMatchObject({});
+                });
+                `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'when expectations for variable1 are mixed with variable2 in one "test"',
+      code: `
+                test('should fail1', function () {
+                  expect(variable1).toBeDefined();
+                  expect(variable2).toEqual({});
+                  expect(variable1).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable1',
+          },
+        },
+      ],
+    },
+    {
+      name: 'when expectations for objects variable1.property1 are mixed with variable2 in one "test"',
+      code: `
+                test('should fail1', function () {
+                  expect(variable1.property1).toBeDefined();
+                  expect(variable2).toEqual({});
+                  expect(variable1.property1).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable1',
+          },
+        },
+      ],
+    },
+    {
+      name: 'when expectations for variable1 object\'s properties are mixed with variable2 in one "test"',
+      code: `
+                test('should fail1', function () {
+                  expect(variable1.property1).toBeDefined();
+                  expect(variable2).toEqual({});
+                  expect(variable1.property2).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable1',
+          },
+        },
+      ],
+    },
+    {
+      name: 'when expectations for variable1 are mixed with variable2 object\'s properties in one "test"',
+      code: `
+                test('should fail1', function () {
+                  expect(variable1).toBeDefined();
+                  expect(variable2.status).toEqual({});
+                  expect(variable1).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable1',
+          },
+        },
+      ],
+    },
+    {
+      name: 'when expectations for variable1 are mixed with variable2 in one "it"',
+      code: `
+                it('should fail1', function () {
+                  expect(variable1).toBeDefined();
+                  expect(variable2).toEqual({});
+                  expect(variable1).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable1',
+          },
+        },
+      ],
+    },
+    {
+      name: 'when expectations for variables are mixed in both "it"',
+      code: `
+                it('should fail1', function () {
+                  expect(variable1).toBeDefined();
+                  expect(variable2).toEqual({});
+                  expect(variable1).toEqual({});
+                });
+                it('should fail2', function () {
+                  expect(variable3).toBeDefined();
+                  expect(variable4).toEqual({});
+                  expect(variable3).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable1',
+          },
+        },
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable3',
+          },
+        },
+      ],
+    },
+    {
+      name: 'when expectations for variables are mixed in the first "it"',
+      code: `
+                it('should fail1', function () {
+                  expect(variable1).toBeDefined();
+                  expect(variable2).toEqual({});
+                  expect(variable1).toEqual({});
+                });
+                it('should fail2', function () {
+                  expect(variable3).toBeDefined();
+                  expect(variable4).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable1',
+          },
+        },
+      ],
+    },
+    {
+      name: 'when expectations for variables are mixed in the second "it"',
+      code: `
+                it('should fail1', function () {
+                  expect(variable1).toBeDefined();
+                  expect(variable2).toEqual({});
+                });
+                it('should fail2', function () {
+                  expect(variable3).toBeDefined();
+                  expect(variable4).toEqual({});
+                  expect(variable3).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable3',
+          },
+        },
+      ],
+    },
+    {
+      name: 'when expectations for variables are mixed in both "test.each"',
+      code: `
+                test.each(['should fail1'], function () {
+                  expect(variable1).toBeDefined();
+                  expect(variable2).toEqual({});
+                  expect(variable1).toEqual({});
+                });
+                test.each(['should fail2'], function () {
+                  expect(variable3).toBeDefined();
+                  expect(variable4).toEqual({});
+                  expect(variable3).toEqual({});
+                });
+                `,
+      output: null,
+      errors: [
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable1',
+          },
+        },
+        {
+          messageId: 'noMixedExpectationGroups',
+          data: {
+            variable: 'variable3',
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/src/custom-rules/no-mixed-expectation-groups.ts
+++ b/src/custom-rules/no-mixed-expectation-groups.ts
@@ -1,0 +1,87 @@
+import { AST_NODE_TYPES, ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+import { isParentATestFunction } from './utils/is-parent-a-test-function';
+
+type MessageIds = 'noMixedExpectationGroups';
+type Options = [];
+
+type FunctionExpression = TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression;
+
+export const noMixedExpectationGroups = ESLintUtils.RuleCreator.withoutDocs<Options, MessageIds>({
+  create(context) {
+    let variableIndex = 1;
+    let variableIndexInExpectations: Record<string, number> = {};
+
+    const resetMatchersIfIsTestFunction = (node: FunctionExpression): void => {
+      if (isParentATestFunction(node)) {
+        variableIndexInExpectations = {};
+      }
+    };
+
+    return {
+      FunctionExpression: resetMatchersIfIsTestFunction,
+      'FunctionExpression:exit': resetMatchersIfIsTestFunction,
+      ArrowFunctionExpression: resetMatchersIfIsTestFunction,
+      'ArrowFunctionExpression:exit': resetMatchersIfIsTestFunction,
+      CallExpression(node) {
+        if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+          return;
+        }
+
+        if (node.callee.property.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+
+        if (
+          node.callee.object.type !== AST_NODE_TYPES.CallExpression ||
+          node.callee.object.callee.type !== AST_NODE_TYPES.Identifier ||
+          node.callee.object.callee.name !== 'expect'
+        ) {
+          return;
+        }
+
+        const expectFirstArgument = node.callee.object.arguments[0];
+
+        let variableName = '';
+
+        if (expectFirstArgument.type === AST_NODE_TYPES.Identifier) {
+          variableName = expectFirstArgument.name;
+        } else if (
+          expectFirstArgument.type === AST_NODE_TYPES.MemberExpression &&
+          expectFirstArgument.object.type === AST_NODE_TYPES.Identifier
+        ) {
+          variableName = expectFirstArgument.object.name;
+        }
+
+        if (
+          variableIndexInExpectations.hasOwnProperty(variableName) &&
+          variableIndexInExpectations[variableName] !== variableIndex - 1
+        ) {
+          context.report({
+            node,
+            messageId: 'noMixedExpectationGroups',
+            data: {
+              variable: variableName,
+            },
+          });
+        } else {
+          variableIndexInExpectations[variableName] = variableIndex;
+        }
+
+        variableIndex += 1;
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description: 'Disallow mixing expectations for different variables between each other.',
+    },
+    messages: {
+      noMixedExpectationGroups:
+        'Expectation for variable "{{ variable }}" should be moved above to the same place where it is check for the first time. Do not mix expectations of different variables.',
+    },
+    type: 'suggestion',
+    schema: [],
+  },
+  defaultOptions: [],
+});

--- a/src/custom-rules/utils/is-parent-a-test-function.ts
+++ b/src/custom-rules/utils/is-parent-a-test-function.ts
@@ -1,0 +1,25 @@
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+
+type FunctionExpression = TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression;
+
+const TEST_FUNCTIONS = ['test', 'it'];
+
+export const isParentATestFunction = (node: FunctionExpression): boolean => {
+  if (node.parent.type !== AST_NODE_TYPES.CallExpression) {
+    return false;
+  }
+
+  const parentCallee = node.parent.callee;
+
+  const isParentTestFunction =
+    parentCallee.type === AST_NODE_TYPES.Identifier && TEST_FUNCTIONS.includes(parentCallee.name);
+
+  const isParentTestEachFunction =
+    parentCallee.type === AST_NODE_TYPES.MemberExpression &&
+    parentCallee.object.type === AST_NODE_TYPES.Identifier &&
+    TEST_FUNCTIONS.includes(parentCallee.object.name) &&
+    parentCallee.property.type === AST_NODE_TYPES.Identifier &&
+    parentCallee.property.name === 'each';
+
+  return isParentTestFunction || isParentTestEachFunction;
+};

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -2,7 +2,11 @@ import plugin from './plugin';
 
 describe('proper tests plugin', (): void => {
   test('it exports all rules', (): void => {
-    expect(Object.keys(plugin.rules)).toEqual(['no-useless-matcher-to-be-defined', 'no-useless-matcher-to-be-null']);
+    expect(Object.keys(plugin.rules)).toEqual([
+      'no-useless-matcher-to-be-defined',
+      'no-useless-matcher-to-be-null',
+      'no-mixed-expectation-groups',
+    ]);
   });
 
   test('it exposes recommended plugin', (): void => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,7 @@
 import type { Linter } from '@typescript-eslint/utils/ts-eslint';
 
 import recommended from './configs/recommended';
+import { noMixedExpectationGroups } from './custom-rules/no-mixed-expectation-groups';
 import { noUselessMatcherToBeDefined } from './custom-rules/no-useless-matcher-to-be-defined';
 import { noUselessMatcherToBeNull } from './custom-rules/no-useless-matcher-to-be-null';
 
@@ -11,5 +12,6 @@ export = {
   rules: {
     'no-useless-matcher-to-be-defined': noUselessMatcherToBeDefined,
     'no-useless-matcher-to-be-null': noUselessMatcherToBeNull,
+    'no-mixed-expectation-groups': noMixedExpectationGroups,
   },
 } satisfies Linter.Plugin;


### PR DESCRIPTION
This rule disallows mixing expectations for different variables between each other.

The following patterns are considered errors:

```ts
// example 1
expect(foo).toBeDefined();
expect(bar).toBeNull();
expect(foo).toHaveLength(3); // should be placed before "bar"

// example 1
expect(foo).toBeDefined();
expect(bar).toBeNull();
expect(foo.bars).toHaveLength(3); // should be placed before "bar"
```

The following patterns are considered correct:

```ts
// example 1
expect(foo).toBeDefined();
expect(foo).toHaveLength(3);

expect(bar).toBeNull();

// example 2
expect(foo).toBeDefined();
expect(foo.bars).toHaveLength(3);

expect(bar).toBeNull();
```