### PR TITLE
Enable plugin for recommended config so that developers can use the minimal eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ To enable this configuration with `.eslintrc`, use the `extends` property:
 }
 ```
 
+and you are done, no other configuration is needed.
+
 ## Rules
 
 <!-- begin auto-generated rules list -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-proper-tests",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "ESLint rules for writing more proper tests.",
   "keywords": [
     "eslint",

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -1,6 +1,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
+  plugins: ['proper-tests'],
   rules: {
     'proper-tests/no-useless-matcher-to-be-defined': 'error',
     'proper-tests/no-useless-matcher-to-be-null': 'error',


### PR DESCRIPTION
Enable plugin for recommended config so that developers can use the minimal eslint config

```json
{
  "extends": ["plugin:proper-tests/recommended"]
}
```

Fixes https://github.com/maks-rafalko/eslint-plugin-proper-tests/issues/7